### PR TITLE
Fix iOS build failure by setting IPHONEOS_DEPLOYMENT_TARGET

### DIFF
--- a/TapyrusWalletSwift/Package.swift.txt
+++ b/TapyrusWalletSwift/Package.swift.txt
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "TapyrusWalletSwift",
     platforms: [
-        .iOS(.v13)
+        .iOS(.v16)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/TapyrusWalletSwift/create_xcframework.sh
+++ b/TapyrusWalletSwift/create_xcframework.sh
@@ -20,12 +20,17 @@ rustup target add x86_64-apple-darwin    # mac x86_64
 
 cd ../tapyrus-wallet-ffi/ || exit
 
-# build tapyrus-wallet-ffi rust lib for apple targets
+# build tapyrus-wallet-ffi rust lib for apple targets (macOS)
 cargo build --package tapyrus-wallet-ffi --profile release-smaller --target x86_64-apple-darwin
 cargo build --package tapyrus-wallet-ffi --profile release-smaller --target aarch64-apple-darwin
+
+# build tapyrus-wallet-ffi rust lib for apple targets (iOS)
+# Set iOS deployment target to prevent ___chkstk_darwin linker errors from aws-lc-sys
+export IPHONEOS_DEPLOYMENT_TARGET=16.0
 cargo build --package tapyrus-wallet-ffi --profile release-smaller --target x86_64-apple-ios
 cargo build --package tapyrus-wallet-ffi --profile release-smaller --target aarch64-apple-ios
 cargo build --package tapyrus-wallet-ffi --profile release-smaller --target aarch64-apple-ios-sim
+unset IPHONEOS_DEPLOYMENT_TARGET
 
 # build tapyrus-wallet-ffi Swift bindings and put in TapyrusWallsetSwift Sources
 cargo run --bin uniffi-bindgen generate --library ./target/aarch64-apple-ios/release-smaller/libtapyrus_wallet_ffi.dylib --language swift --out-dir ../TapyrusWalletSwift/Sources/TapyrusWallet --no-format


### PR DESCRIPTION
## Summary
- Set `IPHONEOS_DEPLOYMENT_TARGET=16.0` in `create_xcframework.sh` for iOS target builds to fix `___chkstk_darwin` linker error from `aws-lc-sys`
- Raise minimum iOS deployment target from 13.0 to 16.0 in `Package.swift.txt`
- Scope the environment variable to iOS builds only (unset after iOS builds, before uniffi-bindgen)

## Background
The publish workflow ([TapyrusWalletSwift #12](https://github.com/chaintope/TapyrusWalletSwift/actions/runs/22211926240)) fails at the `Create tapyrus_wallet_ffi.xcframework` step with:

```
Undefined symbols for architecture arm64:
  "___chkstk_darwin", referenced from:
    _aws_lc_0_34_0_pqcrystals_kyber512_ref_indcpa_keypair_derand ...
```

`___chkstk_darwin` is a stack probe function available on macOS and iOS 13+, but Rust's `aarch64-apple-ios` target defaults to iOS 10.0. Without an explicit `IPHONEOS_DEPLOYMENT_TARGET`, the C compiler in `aws-lc-sys` inherits the host macOS SDK version, generating `___chkstk_darwin` references that cannot be resolved when linking for iOS 10.0.

## Verified locally
- **Without fix**: `___chkstk_darwin` linker error reproduced
- **With fix**: Build succeeds (warnings only)

## Test plan
- [ ] Re-run the publish workflow with this branch to confirm the XCFramework builds successfully
- [ ] Verify the generated XCFramework works in a sample iOS project targeting iOS 16.0+

🤖 Generated with [Claude Code](https://claude.com/claude-code)