### PR TITLE
Bump swift-tools-version from 5.5 to 5.7

### DIFF
--- a/TapyrusWalletSwift/Package.swift.txt
+++ b/TapyrusWalletSwift/Package.swift.txt
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
## Summary
- Bump `swift-tools-version` from 5.5 to 5.7 in `Package.swift.txt`

## Background
After merging #9 (`.iOS(.v16)`), the DocC documentation build step in the publish workflow fails with:

```
Package.swift:10:15: error: 'v16' is unavailable
    .iOS(.v16)
          ^~~
note: 'v16' was introduced in PackageDescription 5.7
```

`.iOS(.v16)` requires `PackageDescription` 5.7+, which corresponds to `swift-tools-version:5.7`.

## Test plan
- [ ] Re-run the publish workflow and confirm DocC generation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)