### PR TITLE
Add connection settings UI to Swift example app

### DIFF
--- a/TapyrusWalletSwift/example/example.xcodeproj/project.pbxproj
+++ b/TapyrusWalletSwift/example/example.xcodeproj/project.pbxproj
@@ -590,7 +590,7 @@
 			repositoryURL = "https://github.com/chaintope/TapyrusWalletSwift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.1;
+				minimumVersion = "0.1.4-beta.3";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/TapyrusWalletSwift/example/example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TapyrusWalletSwift/example/example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/chaintope/TapyrusWalletSwift",
       "state" : {
-        "revision" : "101635bf2273faf496bbfd3857231e4f79d72677",
-        "version" : "0.1.1"
+        "revision" : "c1a85dfdf6d890c4bb5206a781d44d5a7ba511bf",
+        "version" : "0.1.4-beta.3"
       }
     }
   ],

--- a/TapyrusWalletSwift/example/example/ConnectionSettings.swift
+++ b/TapyrusWalletSwift/example/example/ConnectionSettings.swift
@@ -1,0 +1,26 @@
+//
+//  ConnectionSettings.swift
+//  example
+//
+
+import Foundation
+
+enum ConnectionType: String, CaseIterable {
+    case esplora
+    case electrum
+}
+
+enum SettingsKey {
+    static let connectionType = "connectionType"
+    static let esploraHost = "esploraHost"
+    static let esploraPort = "esploraPort"
+    static let electrumHost = "electrumHost"
+    static let electrumPort = "electrumPort"
+}
+
+enum DefaultConnection {
+    static let esploraHost = "localhost"
+    static let esploraPort = "3001"
+    static let electrumHost = "localhost"
+    static let electrumPort = "50001"
+}

--- a/TapyrusWalletSwift/example/example/ContentView.swift
+++ b/TapyrusWalletSwift/example/example/ContentView.swift
@@ -18,8 +18,7 @@ struct ContentView: View {
     @State private var transferErrorMessage = ""
     @State private var showTransferSuccess = false
     @State private var transactionId = ""
-    
-    let mode: Network = .prod
+    @State private var showSettings = false
     
     var body: some View {
         NavigationView {
@@ -128,12 +127,46 @@ struct ContentView: View {
                         Text("Syncing...")
                             .foregroundColor(.secondary)
                     }
+                } else if let result = walletManager.syncResult {
+                    switch result {
+                    case .success:
+                        Label("Sync completed successfully", systemImage: "checkmark.circle.fill")
+                            .foregroundColor(.green)
+                            .font(.subheadline)
+                    case .failure(let message):
+                        VStack(alignment: .leading, spacing: 4) {
+                            Label("Sync failed", systemImage: "xmark.circle.fill")
+                                .foregroundColor(.red)
+                                .font(.subheadline)
+                            Text(message)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .lineLimit(3)
+                        }
+                    }
                 }
-                
+
+                if let info = walletManager.connectionInfo {
+                    Text(info)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
                 Spacer()
             }
             .padding()
             .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: { showSettings = true }) {
+                        Image(systemName: "gearshape")
+                    }
+                }
+            }
+            .sheet(isPresented: $showSettings) {
+                SettingsView()
+                    .environmentObject(walletManager)
+            }
             .alert("Address Copied", isPresented: $showCopiedAlert) {
                 Button("OK", role: .cancel) {}
             } message: {

--- a/TapyrusWalletSwift/example/example/SettingsView.swift
+++ b/TapyrusWalletSwift/example/example/SettingsView.swift
@@ -1,0 +1,104 @@
+//
+//  SettingsView.swift
+//  example
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    @EnvironmentObject private var walletManager: TapyrusWalletManager
+    @Environment(\.dismiss) private var dismiss
+
+    @AppStorage(SettingsKey.connectionType)
+    private var connectionType: String = ConnectionType.esplora.rawValue
+
+    @AppStorage(SettingsKey.esploraHost)
+    private var esploraHost: String = DefaultConnection.esploraHost
+
+    @AppStorage(SettingsKey.esploraPort)
+    private var esploraPort: String = DefaultConnection.esploraPort
+
+    @AppStorage(SettingsKey.electrumHost)
+    private var electrumHost: String = DefaultConnection.electrumHost
+
+    @AppStorage(SettingsKey.electrumPort)
+    private var electrumPort: String = DefaultConnection.electrumPort
+
+    @State private var showError = false
+    @State private var errorMessage = ""
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section("Connection Method") {
+                    Picker("Type", selection: $connectionType) {
+                        Text("Esplora").tag(ConnectionType.esplora.rawValue)
+                        Text("Electrum").tag(ConnectionType.electrum.rawValue)
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                if connectionType == ConnectionType.esplora.rawValue {
+                    Section("Esplora Server") {
+                        TextField("Host", text: $esploraHost)
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .keyboardType(.URL)
+                        TextField("Port", text: $esploraPort)
+                            .keyboardType(.numberPad)
+                    }
+                } else {
+                    Section("Electrum Server") {
+                        TextField("Host", text: $electrumHost)
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .keyboardType(.URL)
+                        TextField("Port", text: $electrumPort)
+                            .keyboardType(.numberPad)
+                    }
+                }
+
+                Section {
+                    Button(action: applySettings) {
+                        HStack {
+                            Image(systemName: "arrow.triangle.2.circlepath")
+                            Text("Apply & Reinitialize Wallet")
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                    .disabled(!isValid)
+                }
+            }
+            .navigationTitle("Connection Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                }
+            }
+            .alert("Error", isPresented: $showError) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(errorMessage)
+            }
+        }
+    }
+
+    private var isValid: Bool {
+        if connectionType == ConnectionType.esplora.rawValue {
+            return !esploraHost.isEmpty && !esploraPort.isEmpty && UInt16(esploraPort) != nil
+        } else {
+            return !electrumHost.isEmpty && !electrumPort.isEmpty && UInt16(electrumPort) != nil
+        }
+    }
+
+    private func applySettings() {
+        do {
+            try walletManager.reinitializeWallet()
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+            showError = true
+        }
+    }
+}

--- a/TapyrusWalletSwift/example/example/TapyrusWalletManager.swift
+++ b/TapyrusWalletSwift/example/example/TapyrusWalletManager.swift
@@ -25,17 +25,24 @@ class TapyrusWalletManager: ObservableObject {
     @Published var currentAddress: String = ""
     @Published var balance: Double = 0.0
     @Published var isSyncing: Bool = false
-    
+    @Published var connectionInfo: String?
+    @Published var syncResult: SyncResult?
+
+    enum SyncResult {
+        case success
+        case failure(String)
+    }
+
     // The wallet instance
     private var wallet: HdWallet?
-    
+
     // Network mode
     private let networkMode: Network = .prod
-    
+
     // Keychain constants
     private let keychainService = "com.example.TapyrusWalletApp"
     private let masterKeyAccount = "masterKey"
-    
+
     // Initialize the wallet manager
     init() {
         do {
@@ -44,12 +51,12 @@ class TapyrusWalletManager: ObservableObject {
             print("Failed to setup wallet: \(error)")
         }
     }
-    
+
     // Setup the wallet - create or load from storage
     private func setupWallet() throws {
         // Check if we have a master key in the keychain
         var masterKey: String
-        
+
         if let storedMasterKey = loadMasterKeyFromKeychain() {
             // Use the stored master key
             masterKey = storedMasterKey
@@ -57,37 +64,70 @@ class TapyrusWalletManager: ObservableObject {
         } else {
             // Generate a new master key
             masterKey = TapyrusWallet.generateMasterKey(networkMode: networkMode)
-            
+
             // Save the master key to keychain
             if !saveMasterKeyToKeychain(masterKey) {
                 throw WalletError.keychainSaveFailed
             }
             print("Generated and saved new master key")
         }
-        
+
         // Get the Documents directory path which is more accessible in iOS apps
         let documentsDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
         let dbFilePath = documentsDir.appendingPathComponent("tapyrus_wallet.db").path
-        
+
         // Ensure the directory exists
         try? FileManager.default.createDirectory(at: documentsDir, withIntermediateDirectories: true)
-        
+
         print("Database path: \(dbFilePath)")
-        
-        // Create wallet configuration with testnet values and the master key
-        let config = Config(
-            networkMode: networkMode,
-            networkId: 1939510133,
-            genesisHash: "038b114875c2f78f5a2fd7d8549a905f38ea5faee6e29a3d79e547151d6bdd8a",
-            esploraUrl: "http://localhost:3001",
-            masterKey: masterKey,
-            dbFilePath: dbFilePath
-        )
-        
+
+        // Read connection settings from UserDefaults
+        let defaults = UserDefaults.standard
+        let connectionType = defaults.string(forKey: SettingsKey.connectionType) ?? ConnectionType.esplora.rawValue
+
+        let config: Config
+
+        if connectionType == ConnectionType.electrum.rawValue {
+            let host = defaults.string(forKey: SettingsKey.electrumHost) ?? DefaultConnection.electrumHost
+            let portStr = defaults.string(forKey: SettingsKey.electrumPort) ?? DefaultConnection.electrumPort
+            let port = UInt16(portStr) ?? 50001
+
+            config = Config(
+                networkMode: networkMode,
+                networkId: 1939510133,
+                genesisHash: "038b114875c2f78f5a2fd7d8549a905f38ea5faee6e29a3d79e547151d6bdd8a",
+                electrumDomain: host,
+                electrumPort: port,
+                masterKey: masterKey,
+                dbFilePath: dbFilePath
+            )
+
+            DispatchQueue.main.async { [weak self] in
+                self?.connectionInfo = "Electrum: \(host):\(port)"
+            }
+        } else {
+            let host = defaults.string(forKey: SettingsKey.esploraHost) ?? DefaultConnection.esploraHost
+            let portStr = defaults.string(forKey: SettingsKey.esploraPort) ?? DefaultConnection.esploraPort
+            let esploraUrl = "http://\(host):\(portStr)"
+
+            config = Config(
+                networkMode: networkMode,
+                networkId: 1939510133,
+                genesisHash: "038b114875c2f78f5a2fd7d8549a905f38ea5faee6e29a3d79e547151d6bdd8a",
+                esploraUrl: esploraUrl,
+                masterKey: masterKey,
+                dbFilePath: dbFilePath
+            )
+
+            DispatchQueue.main.async { [weak self] in
+                self?.connectionInfo = "Esplora: \(esploraUrl)"
+            }
+        }
+
         // Create a new wallet with the configuration
         do {
             wallet = try HdWallet(config: config)
-            
+
             // Perform initial sync
             syncWallet()
         } catch {
@@ -95,28 +135,40 @@ class TapyrusWalletManager: ObservableObject {
             throw WalletError.walletInitializationFailed
         }
     }
-    
+
+    // Reinitialize the wallet with current settings
+    func reinitializeWallet() throws {
+        wallet = nil
+
+        DispatchQueue.main.async { [weak self] in
+            self?.currentAddress = ""
+            self?.balance = 0.0
+        }
+
+        try setupWallet()
+    }
+
     // Save master key to keychain
     private func saveMasterKeyToKeychain(_ key: String) -> Bool {
         guard let data = key.data(using: .utf8) else {
             return false
         }
-        
+
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: keychainService,
             kSecAttrAccount as String: masterKeyAccount,
             kSecValueData as String: data
         ]
-        
+
         // Delete any existing key before saving
         SecItemDelete(query as CFDictionary)
-        
+
         // Add the new key
         let status = SecItemAdd(query as CFDictionary, nil)
         return status == errSecSuccess
     }
-    
+
     // Load master key from keychain
     private func loadMasterKeyFromKeychain() -> String? {
         let query: [String: Any] = [
@@ -126,74 +178,79 @@ class TapyrusWalletManager: ObservableObject {
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne
         ]
-        
+
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
-        
+
         if status == errSecSuccess, let data = result as? Data, let masterKey = String(data: data, encoding: .utf8) {
             return masterKey
         }
         return nil
     }
-    
+
     // Sync the wallet with the blockchain
     func syncWallet() {
         guard let wallet = wallet else { return }
-        
+
         DispatchQueue.global(qos: .background).async { [weak self] in
-            self?.isSyncing = true
-            
+            DispatchQueue.main.async {
+                self?.isSyncing = true
+                self?.syncResult = nil
+            }
+
             do {
                 // Perform full sync
                 try wallet.fullSync()
-                
+
                 // Update balance
                 self?.updateBalance()
-                
+
                 DispatchQueue.main.async {
                     self?.isSyncing = false
+                    self?.syncResult = .success
                 }
             } catch {
                 print("Sync error: \(error)")
                 DispatchQueue.main.async {
                     self?.isSyncing = false
+                    self?.syncResult = .failure("\(error)")
                 }
             }
         }
     }
-    
+
     // Generate a new address
     func getNewAddress() -> String {
         guard let wallet = wallet else { return "" }
         debugPrint(wallet)
-        
+
         do {
             // Call the wallet's getNewAddress function with colorId set to nil
             let result = try wallet.getNewAddress(colorId: nil)
             let address = result.address
-            
+
             DispatchQueue.main.async { [weak self] in
                 self?.currentAddress = address
             }
-            
+
             return address
         } catch {
             print("Error generating address: \(error)")
             return ""
         }
     }
-    
+
     // Update the wallet balance
     private func updateBalance() {
         guard let wallet = wallet else { return }
-        
+
         do {
             // Call the wallet's balance function with colorId set to nil for TPC
             let balanceValue = try wallet.balance(colorId: nil)
-            
+
             // Convert to Double for display (balance is in satoshis, convert to TPC)
             let tpcBalance = Double(balanceValue) / 100_000_000.0
-            
+
             DispatchQueue.main.async { [weak self] in
                 self?.balance = tpcBalance
             }
@@ -201,25 +258,25 @@ class TapyrusWalletManager: ObservableObject {
             print("Error getting balance: \(error)")
         }
     }
-    
+
     // Transfer TPC to another address
     func transfer(toAddress: String, amount: Double) async throws -> String {
         guard let wallet = wallet else {
             throw WalletError.walletInitializationFailed
         }
-        
+
         // Convert amount from TPC to satoshis (smallest unit)
         let amountInSatoshis = UInt64(amount * 100_000_000.0)
-        
+
         // Create transfer parameters
         let transferParams = TransferParams(amount: amountInSatoshis, toAddress: toAddress)
-        
+
         // Execute the transfer
         let txid = try wallet.transfer(params: [transferParams], utxos: [])
-        
+
         // Update balance after transfer
         updateBalance()
-        
+
         return txid
     }
 }


### PR DESCRIPTION
## Summary
- Add settings screen to switch between Esplora and Electrum backends with configurable host/port
- Show sync success/failure status below the Sync Wallet button
- Display current connection info on the main screen
- Update SPM dependency to TapyrusWalletSwift 0.1.4-beta.3 (Electrum support)

## Changes
- **New**: `ConnectionSettings.swift` — `ConnectionType` enum, UserDefaults keys, defaults
- **New**: `SettingsView.swift` — Settings UI with Segmented Picker, host/port fields, validation
- **Modified**: `TapyrusWalletManager.swift` — Read connection settings from UserDefaults, `reinitializeWallet()`, sync result tracking
- **Modified**: `ContentView.swift` — Toolbar gear icon, sync result display, connection info label

## Test plan
- [x] Build and run on iOS Simulator
- [x] Verify Esplora connection with default settings (localhost:3001)
- [x] Verify Electrum connection with default settings (localhost:50001)
- [x] Verify settings persist after app restart
- [x] Verify sync success/failure status is displayed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)